### PR TITLE
Remove deprecated step to move junit.xml to the right place from CircleCI config

### DIFF
--- a/src/circleci/templates/config.yml
+++ b/src/circleci/templates/config.yml
@@ -56,9 +56,6 @@ jobs:
       - run:
           name: Run tests
           command: yarn run test:ci
-      - run:
-          name: Move JUnit report to reports directory
-          command: mkdir -p ./reports/junit && mv junit.xml ./reports/junit/
       - store_test_results:
           path: ./reports
       - store_artifacts:


### PR DESCRIPTION
Fixes a bug causing CircleCI builds to fail for the generated package.