### PR TITLE
Ignore everything in .yarn directory for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,2 +1,2 @@
 exclude_patterns:
-  - "**/.yarn/cache"
+  - "**/.yarn"


### PR DESCRIPTION
Still picking up a few quality issues in `.yarn/sdks` without this.