### PR TITLE
Fix potential bug where private generator methods would be run independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Built files
 generators
 
-# Secrets
+# Environment Variables -- May Contain Secrets
 .env
 
 # Test Coverage

--- a/src/__tests__/__utils__/testGenerators/ComposeWithSubGeneratorTestGenerator.ts
+++ b/src/__tests__/__utils__/testGenerators/ComposeWithSubGeneratorTestGenerator.ts
@@ -32,7 +32,7 @@ export class ComposeWithSubGeneratorTestGenerator extends BaseGenerator<ComposeW
     this.writeDestinationJSON("parentOptions.json", options);
   }
 
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators() {
     return [
       {
         Generator: InheritedOptionsSubGeneratorTestGenerator,

--- a/src/app/TypeScriptPackageGenerator.ts
+++ b/src/app/TypeScriptPackageGenerator.ts
@@ -39,7 +39,7 @@ export class TypeScriptPackageGenerator extends BaseGenerator {
     this.spawnCommandSync("yarn", yarnArgs);
   }
 
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators = () => {
     return [
       {
         Generator: GitignoreGenerator,
@@ -74,5 +74,5 @@ export class TypeScriptPackageGenerator extends BaseGenerator {
         path: path.join(__dirname, "../github"),
       },
     ];
-  }
+  };
 }

--- a/src/git/GitGenerator.ts
+++ b/src/git/GitGenerator.ts
@@ -27,12 +27,12 @@ export class GitGenerator extends BaseGenerator {
     ]);
   }
 
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators = () => {
     return [
       {
         Generator: GitHooksGenerator,
         path: path.join(__dirname, "./git-hooks"),
       },
     ];
-  }
+  };
 }

--- a/src/git/git-hooks/GitHooksGenerator.ts
+++ b/src/git/git-hooks/GitHooksGenerator.ts
@@ -34,7 +34,7 @@ export class GitHooksGenerator extends BaseGenerator {
     ]);
   }
 
-  private async writePackageJson() {
+  private writePackageJson = async () => {
     const scripts = {
       prepare: "husky install",
     };
@@ -45,5 +45,5 @@ export class GitHooksGenerator extends BaseGenerator {
       name: "husky",
       comment: "Modern native Git hooks made easy",
     });
-  }
+  };
 }

--- a/src/github/GitHubGenerator.test.ts
+++ b/src/github/GitHubGenerator.test.ts
@@ -432,7 +432,7 @@ const runGenerator = (options: Partial<GitHubGeneratorOptions> = {}) => {
 };
 
 class GitHubTestGenerator extends BaseGenerator {
-  public getSubGeneratorOptions() {
+  public configureSubGenerators() {
     return [
       {
         Generator: GitHubGenerator,

--- a/src/gitignore/templates/.gitignore.ejs
+++ b/src/gitignore/templates/.gitignore.ejs
@@ -1,3 +1,6 @@
+# Environment Variables -- May Contain Secrets
+.env
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/src/node-module/NodeModuleGenerator.ts
+++ b/src/node-module/NodeModuleGenerator.ts
@@ -52,20 +52,24 @@ export class NodeModuleGenerator extends BaseGenerator<NodeModuleGeneratorOption
     this.writePackageJson();
   }
 
-  protected getSubGeneratorOptions() {
+  public install() {
+    this.spawnCommandSync("yarn", ["set", "version", "3.2.1"]);
+  }
+
+  protected configureSubGenerators = () => {
     return [
       {
         Generator: ReadmeGenerator,
         path: path.join(__dirname, "./readme"),
       },
     ];
-  }
+  };
 
-  private writeGitignore() {
+  private writeGitignore = () => {
     this.writeOrAppendGitignore(".gitignore.ejs");
-  }
+  };
 
-  private writePackageJson() {
+  private writePackageJson = () => {
     const keywordTokens = this.answers.packageKeywords?.split(" ") || [];
     const keywords = keywordTokens.map((token) => `"${token}"`).join(", ");
 
@@ -76,9 +80,5 @@ export class NodeModuleGenerator extends BaseGenerator<NodeModuleGeneratorOption
       keywords,
       githubUrl,
     });
-  }
-
-  public install() {
-    this.spawnCommandSync("yarn", ["set", "version", "3.2.1"]);
-  }
+  };
 }

--- a/src/shared/BaseGenerator.ts
+++ b/src/shared/BaseGenerator.ts
@@ -14,7 +14,7 @@ interface WriteOrAppendOptions {
   leadingNewlineOnAppend?: boolean;
 }
 
-interface SubGeneratorCompositionOptions<T> {
+interface SubGeneratorCompositionConfig<T> {
   Generator: SubGeneratorConstructor<T>;
   path: string;
 }
@@ -108,8 +108,8 @@ export abstract class BaseGenerator<
 
     this.extendPackageJson({ devDependenciesComments: dependencyComments });
 
-    await this.addDevDependencies(dependenciesWithVersions);
-    await this.addDevDependencies(dependenciesWithoutVersions);
+    await super.addDevDependencies(dependenciesWithVersions);
+    await super.addDevDependencies(dependenciesWithoutVersions);
   }
 
   /**
@@ -134,7 +134,7 @@ export abstract class BaseGenerator<
     });
   }
 
-  protected getSubGeneratorOptions(): SubGeneratorCompositionOptions<any>[] {
+  protected configureSubGenerators(): SubGeneratorCompositionConfig<any>[] {
     return [];
   }
 
@@ -162,8 +162,8 @@ export abstract class BaseGenerator<
   }
 
   private initializeSubGenerators() {
-    const subGeneratorOptions = this.getSubGeneratorOptions();
-    this.composeWithSubGenerators(subGeneratorOptions);
+    const subGenerators = this.configureSubGenerators();
+    this.composeWithSubGenerators(subGenerators);
   }
 
   private addQuestions(questions: Question<T>[]) {
@@ -186,10 +186,10 @@ export abstract class BaseGenerator<
   }
 
   private composeWithSubGenerators(
-    subGeneratorOptions: SubGeneratorCompositionOptions<any>[]
+    subGenerators: SubGeneratorCompositionConfig<any>[]
   ): BaseGenerator<any>[] {
     return super.composeWith(
-      subGeneratorOptions,
+      subGenerators,
       {
         ...this.options,
         ...this.answers,

--- a/src/testing/TestingGenerator.ts
+++ b/src/testing/TestingGenerator.ts
@@ -5,7 +5,7 @@ import { JestGenerator } from "./jest";
 import { TestCoverageGenerator } from "./test-coverage";
 
 export class TestingGenerator extends BaseGenerator {
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators() {
     return [
       {
         Generator: JestGenerator,

--- a/src/testing/test-coverage/TestCoverageGenerator.ts
+++ b/src/testing/test-coverage/TestCoverageGenerator.ts
@@ -4,7 +4,7 @@ import { BaseGenerator } from "../../shared/index";
 import { CodeCovGenerator } from "./codecov/index";
 
 export class TestCoverageGenerator extends BaseGenerator {
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators() {
     return [
       {
         Generator: CodeCovGenerator,

--- a/src/typescript/TypeScriptGenerator.ts
+++ b/src/typescript/TypeScriptGenerator.ts
@@ -13,7 +13,7 @@ export class TypeScriptGenerator extends BaseGenerator {
     });
   }
 
-  protected getSubGeneratorOptions() {
+  protected configureSubGenerators() {
     return [
       {
         Generator: TsConfigGenerator,


### PR DESCRIPTION
Closes #97.

Lightly refactors BaseGenerator naming to make `subGenerators` and `options` distinction more clear.