### PR TITLE
Handle no existing git remote origin url properly

### DIFF
--- a/src/github/GitHubGenerator.test.ts
+++ b/src/github/GitHubGenerator.test.ts
@@ -424,14 +424,16 @@ describe("GitHubGenerator", () => {
   });
 
   describe("remote origin", () => {
-    it("adds the GitHub repo as a git remote origin", async () => {
-      const result = await runGenerator();
+    describe("when a git remote origin doesn't already exist", () => {
+      it("adds the GitHub repo as a git remote origin", async () => {
+        const result = await runGenerator();
 
-      const remoteOriginUrl = getRemoteOriginUrl(result);
+        const remoteOriginUrl = getRemoteOriginUrl(result);
 
-      expect(remoteOriginUrl).toBe(
-        `git@github.com:chiubaka/generated-typescript-package.git`
-      );
+        expect(remoteOriginUrl).toBe(
+          `git@github.com:chiubaka/generated-typescript-package.git`
+        );
+      });
     });
 
     describe("when a git remote origin already exists", () => {

--- a/src/github/GitHubGenerator.ts
+++ b/src/github/GitHubGenerator.ts
@@ -70,7 +70,7 @@ export class GitHubGenerator extends BaseGenerator<GitHubGeneratorOptions> {
 
     const existingRemoteUrl = await this.getRemoteOriginUrl();
 
-    if (!existingRemoteUrl) {
+    if (existingRemoteUrl === "") {
       this.spawnCommandSync("git", ["remote", "add", "origin", githubUrl]);
     } else if (existingRemoteUrl !== githubUrl) {
       this.spawnCommandSync("git", ["remote", "set-url", "origin", githubUrl]);
@@ -252,9 +252,15 @@ export class GitHubGenerator extends BaseGenerator<GitHubGeneratorOptions> {
     });
   };
 
+  /**
+   * Grabs the current remote origin URL from git configs
+   * @returns Promise<string> Empty string ("") when no remote origin exists, a git url otherwise
+   */
   private getRemoteOriginUrl = async () => {
-    const result = await this.exec("git config --get remote.origin.url");
-    return result.stdout;
+    const result = await this.exec(
+      'git config --default "" --get remote.origin.url'
+    );
+    return result.stdout.trim();
   };
 
   /**

--- a/src/shared/BaseGenerator.ts
+++ b/src/shared/BaseGenerator.ts
@@ -161,7 +161,10 @@ export abstract class BaseGenerator<
       return result;
     } catch (error: any) {
       if (ErrorUtils.isExecException(error)) {
-        return error;
+        throw {
+          ...error,
+          message: `${error.message}\n${error.stdout}\n${error.stderr}`,
+        };
       }
 
       throw error;


### PR DESCRIPTION
Closes #119. Clears the path for #116 by ensuring that `exec` still throws if the run command fails (it now attempts to throw a more descriptive exception, however).