### PR TITLE
Replace TypeScriptPackageGenerator with a RootGenerator that selects high-level sub-generators

### DIFF
--- a/config/generatedTypescriptPackage.yml
+++ b/config/generatedTypescriptPackage.yml
@@ -1,3 +1,5 @@
+projectType: TypeScript Package
+
 configGitUser: true
 disableImmutableYarnInstalls: true
 

--- a/src/app/RootGenerator.ts
+++ b/src/app/RootGenerator.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import { GeneratorOptions, Question } from "yeoman-generator";
+
+import { BaseGenerator } from "../shared";
+import TypeScriptPackageGenerator from "../typescript-package";
+
+interface RootGeneratorOptions {
+  config?: string;
+  projectType: GeneratedProjectType;
+}
+
+enum GeneratedProjectType {
+  TypeScriptPackage = "TypeScript Package",
+}
+
+export class RootGenerator extends BaseGenerator<RootGeneratorOptions> {
+  constructor(
+    args: string | string[],
+    options: Partial<RootGeneratorOptions> & GeneratorOptions
+  ) {
+    super(args, options);
+
+    if (this.options.config) {
+      this.loadConfig(this.options.config);
+    }
+  }
+
+  public static getQuestions(): Question<RootGeneratorOptions>[] {
+    return [
+      {
+        type: "list",
+        name: "projectType",
+        message: "What kind of project do you want to generate?",
+        choices: Object.values(GeneratedProjectType),
+        default: GeneratedProjectType.TypeScriptPackage,
+      },
+    ];
+  }
+
+  protected configureSubGenerators() {
+    const { projectType } = this.answers;
+
+    if (projectType === GeneratedProjectType.TypeScriptPackage) {
+      return [
+        {
+          Generator: TypeScriptPackageGenerator,
+          path: path.join(__dirname, "../typescript-package"),
+        },
+      ];
+    }
+
+    return [];
+  }
+
+  public writing() {
+    return;
+  }
+}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,1 +1,1 @@
-export { TypeScriptPackageGenerator as default } from "./TypeScriptPackageGenerator";
+export { RootGenerator as default, RootGenerator } from "./RootGenerator";

--- a/src/typescript-package/TypeScriptPackageGenerator.ts
+++ b/src/typescript-package/TypeScriptPackageGenerator.ts
@@ -1,25 +1,23 @@
 import path from "node:path";
-import { GeneratorOptions, Question } from "yeoman-generator";
+import { Question } from "yeoman-generator";
 
-import { CircleCiGenerator } from "../circleci";
-import { CodeAnalysisGenerator } from "../code-analysis";
-import { EsLintGenerator } from "../eslint";
-import { GitGenerator } from "../git";
+import { CircleCiGenerator } from "../circleci/index";
+import { CodeAnalysisGenerator } from "../code-analysis/index";
+import { EsLintGenerator } from "../eslint/index";
+import { GitGenerator } from "../git/index";
 import { GitHubGenerator, GitHubGeneratorOptions } from "../github/index";
-import { GitignoreGenerator } from "../gitignore";
+import { GitignoreGenerator } from "../gitignore/index";
 import {
   NodeModuleGenerator,
   NodeModuleGeneratorOptions,
-} from "../node-module";
-import { BaseGenerator } from "../shared";
-import { TestingGenerator } from "../testing";
-import { TypeScriptGenerator } from "../typescript";
+} from "../node-module/index";
+import { BaseGenerator } from "../shared/index";
+import { TestingGenerator } from "../testing/index";
+import { TypeScriptGenerator } from "../typescript/index";
 
 export interface TypeScriptPackageGeneratorOptions
   extends NodeModuleGeneratorOptions,
-    GitHubGeneratorOptions {
-  config?: string;
-}
+    GitHubGeneratorOptions {}
 
 export class TypeScriptPackageGenerator extends BaseGenerator<TypeScriptPackageGeneratorOptions> {
   public static getQuestions(): Question<TypeScriptPackageGeneratorOptions>[] {
@@ -27,17 +25,6 @@ export class TypeScriptPackageGenerator extends BaseGenerator<TypeScriptPackageG
       ...NodeModuleGenerator.getQuestions(),
       ...GitHubGenerator.getQuestions(),
     ];
-  }
-
-  constructor(
-    args: string | string[],
-    options: Partial<TypeScriptPackageGeneratorOptions> & GeneratorOptions
-  ) {
-    super(args, options, { customInstallTask: true });
-
-    if (this.options.config) {
-      this.loadConfig(this.options.config);
-    }
   }
 
   public writing() {

--- a/src/typescript-package/index.ts
+++ b/src/typescript-package/index.ts
@@ -1,0 +1,4 @@
+export {
+  TypeScriptPackageGenerator as default,
+  TypeScriptPackageGenerator,
+} from "./TypeScriptPackageGenerator";

--- a/test/integration/TypeScriptPackageGenerator.test.ts
+++ b/test/integration/TypeScriptPackageGenerator.test.ts
@@ -8,7 +8,9 @@ describe("TypeScriptPackageGenerator", () => {
   let result: RunResult;
 
   beforeAll(async () => {
-    result = await YeomanHelpers.create(path.join(__dirname, "../../src/app"))
+    result = await YeomanHelpers.create(
+      path.join(__dirname, "../../src/typescript-package")
+    )
       .withPrompts(NODE_MODULE_GENERATOR_TEST_OPTIONS)
       .withOptions({
         configGitUser: true,


### PR DESCRIPTION
Relates to #144. Paves the way to selecting a "MonorepoGenerator" instead.