### PR TITLE
Allow subgenerators to be configured with custom options when composed

### DIFF
--- a/src/shared/BaseGenerator.ts
+++ b/src/shared/BaseGenerator.ts
@@ -21,9 +21,10 @@ interface WriteOrAppendOptions {
   leadingNewlineOnAppend?: boolean;
 }
 
-interface SubGeneratorCompositionConfig<T> {
+export interface SubGeneratorCompositionConfig<T> {
   Generator: SubGeneratorConstructor<T>;
   path: string;
+  options?: Partial<T>;
 }
 
 interface SubGeneratorConstructor<T> {
@@ -64,7 +65,7 @@ export abstract class BaseGenerator<
     this.queueMethod(
       this.initializeSubGenerators.bind(this),
       "initializeSubGenerators",
-      "prompting"
+      "default"
     );
   }
 
@@ -221,14 +222,20 @@ export abstract class BaseGenerator<
   private composeWithSubGenerators(
     subGenerators: SubGeneratorCompositionConfig<any>[]
   ): BaseGenerator<any>[] {
-    return super.composeWith(
-      subGenerators,
-      {
-        ...this.options,
-        ...this.answers,
-      },
-      true
-    ) as BaseGenerator<any>[];
+    return subGenerators.map((subGenerator) => {
+      return super.composeWith(
+        {
+          Generator: subGenerator.Generator,
+          path: subGenerator.path,
+        },
+        {
+          ...this.options,
+          ...this.answers,
+          ...subGenerator.options,
+        },
+        true
+      ) as BaseGenerator<any>;
+    });
   }
 
   private writeOrAppendDestination(

--- a/test/unit/BaseGenerator.test.ts
+++ b/test/unit/BaseGenerator.test.ts
@@ -155,6 +155,30 @@ describe("BaseGenerator", () => {
           expect(promptSpy).toHaveBeenCalledTimes(1);
         });
       });
+
+      describe("when passed custom options from parent generator", () => {
+        beforeAll(async () => {
+          result = await YeomanTest.create(
+            ComposeWithSubGeneratorTestGenerator,
+            {
+              namespace: "test:compose-with-sub-generator",
+            }
+          )
+            .withOptions({
+              packageName: "test-package",
+              packageDescription: "Test package description",
+              packageKeywords: "test foo bar",
+              yarnInstall: true,
+            })
+            .run();
+        });
+
+        it("receives and can work with custom options", () => {
+          result.assertJsonFileContent("inheritedOptions.json", {
+            customTestOption: "foobar",
+          });
+        });
+      });
     });
   });
 

--- a/test/utils/testGenerators/ComposeWithSubGeneratorTestGenerator.ts
+++ b/test/utils/testGenerators/ComposeWithSubGeneratorTestGenerator.ts
@@ -40,6 +40,9 @@ export class ComposeWithSubGeneratorTestGenerator extends BaseGenerator<ComposeW
           __dirname,
           "./InheritedOptionsSubGeneratorTestGenerator"
         ),
+        options: {
+          customTestOption: "foobar",
+        },
       },
     ];
   }


### PR DESCRIPTION
Relates to #127 and #144. Necessary because we want the `MonorepoGenerator` to be able to configure where package generators generate (i.e. `destinationRoot`). Also because we'll need `MonorepoGenerator` to have the ability to use an existing component generator but with different options / configuration from normal. E.g. The `NodeModuleGenerator` needs to be able to generate a `private` package with a `workspaces` key.